### PR TITLE
Update glow and image

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ categories = ["gui", "rendering"]
 
 [dependencies]
 imgui = { version = "0.12.0", git = "https://github.com/imgui-rs/imgui-rs" }
-glow = "0.14"
+glow = "0.16.0"
 memoffset = "0.9"
 
 [dev-dependencies]
 glutin = "0.32"
 glutin-winit = "0.5"
 imgui-winit-support = { version = "0.13.0", git = "https://github.com/imgui-rs/imgui-winit-support" }
-image = "0.23"
+image = "0.25.5"
 raw-window-handle = "0.6.0"
 winit = { version = "0.30", features = ["rwh_06"] }
 

--- a/examples/glow_03_triangle_gles.rs
+++ b/examples/glow_03_triangle_gles.rs
@@ -2,7 +2,7 @@
 //! using OpenGL ES, rather than full-fat OpenGL.
 //!
 //! Note this example uses `Renderer` rather than `AutoRenderer` and
-//! therefore requries more lifetime-management of the OpenGL context.
+//! therefore requires more lifetime-management of the OpenGL context.
 
 use std::{num::NonZeroU32, time::Instant};
 

--- a/examples/glow_04_custom_textures.rs
+++ b/examples/glow_04_custom_textures.rs
@@ -7,7 +7,7 @@
 
 use std::{io::Cursor, num::NonZeroU32, time::Instant};
 
-use glow::HasContext;
+use glow::{HasContext, PixelUnpackData};
 use glutin::surface::GlSurface;
 use imgui::Condition;
 
@@ -162,7 +162,7 @@ impl TexturesUi {
                 0,
                 glow::RGB,
                 glow::UNSIGNED_BYTE,
-                Some(&data),
+                PixelUnpackData::Slice(Some(&data)),
             )
         }
 
@@ -266,7 +266,7 @@ struct SipiPng {
 
 impl SipiPng {
     fn load(gl: &glow::Context, textures: &mut imgui::Textures<glow::Texture>) -> Self {
-        let sipi_png = image::io::Reader::new(Cursor::new(SIPI_PNG))
+        let sipi_png = image::ImageReader::new(Cursor::new(SIPI_PNG))
             .with_guessed_format()
             .unwrap()
             .decode()
@@ -297,7 +297,7 @@ impl SipiPng {
                 0,
                 glow::RGBA,
                 glow::UNSIGNED_BYTE,
-                Some(&sipi_png),
+                PixelUnpackData::Slice(Some(&sipi_png)),
             )
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use crate::versions::{GlVersion, GlslVersion};
 
 // Re-export glow to make it easier for users to use the correct version.
 pub use glow;
-use glow::{Context, HasContext};
+use glow::{Context, HasContext, PixelUnpackData};
 
 pub mod versions;
 
@@ -1077,7 +1077,7 @@ fn prepare_font_atlas<T: TextureMap>(
             0,
             glow::RGBA,
             glow::UNSIGNED_BYTE,
-            Some(atlas_texture.data),
+            PixelUnpackData::Slice(Some(atlas_texture.data)),
         );
     }
 


### PR DESCRIPTION
Updates glow to 0.16.0 and image to 0.25.5. Fixes a small typo in the 3rd example. 